### PR TITLE
Fix error when compiling gst.

### DIFF
--- a/common.go
+++ b/common.go
@@ -32,7 +32,7 @@ Fields _parse_struct(GstStructure *s) {
 	int n = gst_structure_n_fields(s);
 	Fields f = { malloc(n * sizeof(Field)), 0 };
 	gst_structure_foreach(s, _parse_field, (gpointer)(&f));
-	return f;	
+	return f;
 }
 
 #cgo pkg-config: gstreamer-1.0
@@ -43,7 +43,7 @@ import (
 	"os"
 	"unsafe"
 	"fmt"
-	
+
 	"github.com/ziutek/glib"
 )
 
@@ -184,4 +184,4 @@ func parseGstStructure(s *C.GstStructure) (name string, fields glib.Params) {
 	return
 }
 
-var CLOCK_TIME_NONE = int64(C.GST_CLOCK_TIME_NONE)
+var CLOCK_TIME_NONE = uint64(C.GST_CLOCK_TIME_NONE)


### PR DESCRIPTION
github.com/ziutek/gst/common.go:187: constant 18446744073709551615 overflows int64

I changed to type to uint to fix the error message.